### PR TITLE
feat(parallel_state): complete process group API with SP accessors

### DIFF
--- a/deepspeed/core/parallel_state.py
+++ b/deepspeed/core/parallel_state.py
@@ -1993,6 +1993,35 @@ def get_context_parallel_rank() -> int:
 # TP + CP combined world size / rank
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Sequence parallel (SP) accessors
+#
+# In Megatron-style sequence parallelism the sequence dimension is split
+# across the same ranks that hold the tensor-model-parallel group.  The SP
+# group is therefore identical to the TP group.  These thin wrappers exist
+# so that callers (e.g. attention.py, LayerNorm) can express intent clearly
+# without hard-coding the TP↔SP equivalence.
+# ---------------------------------------------------------------------------
+
+def get_sequence_parallel_group() -> torch.distributed.ProcessGroup:
+    """Return the sequence-parallel process group (same as the TP group)."""
+    return get_tensor_model_parallel_group()
+
+
+def get_sequence_parallel_world_size() -> int:
+    """Return the sequence-parallel world size (same as TP world size)."""
+    return get_tensor_model_parallel_world_size()
+
+
+def get_sequence_parallel_rank() -> int:
+    """Return the caller's rank in the sequence-parallel group (same as TP rank)."""
+    return get_tensor_model_parallel_rank()
+
+
+# ---------------------------------------------------------------------------
+# TP + CP combined world size / rank
+# ---------------------------------------------------------------------------
+
 def get_tensor_and_context_parallel_world_size() -> int:
     """Return world size for the TP + CP combined group."""
     if torch.distributed.is_available() and torch.distributed.is_initialized():


### PR DESCRIPTION
## Summary

Add the missing sequence parallel (SP) accessor APIs to `deepspeed/core/parallel_state.py`.

Partially addresses https://github.com/dylanyunlon/Neuron_SP/issues/26

## What changed

Three functions were imported by `deepspeed/core/transformer/attention.py` but not yet defined in `parallel_state.py`:

- `get_sequence_parallel_group()` → returns the TP group (SP reuses TP ranks)
- `get_sequence_parallel_world_size()` → returns TP world size
- `get_sequence_parallel_rank()` → returns TP rank

Following Megatron-LM convention, sequence parallelism splits the sequence dimension across the same ranks as tensor-model-parallelism. These thin wrappers let callers express intent without hard-coding the TP↔SP equivalence.

## Context

The existing `parallel_state.py` already contains the full TP/PP/DP/CP/EP process group API (114 functions, ported from Megatron-LM with DES-LOC tier-group extensions). This PR fills the last import gap.

## Verification

```bash
python3 -c "from deepspeed.core.parallel_state import get_sequence_parallel_group, get_sequence_parallel_world_size, get_sequence_parallel_rank, initialize_model_parallel; print('OK')"
```