### PR TITLE
fix(desloc_engine): remove debug barriers — fixes #73

### DIFF
--- a/deepspeed/runtime/desloc_engine.py
+++ b/deepspeed/runtime/desloc_engine.py
@@ -1952,6 +1952,12 @@ class DesLocEngine:
         from deepspeed.runtime.core_adapters import build_hybrid_cp_schedule
         _cp_fb = build_hybrid_cp_schedule(cfg)
 
+        # Synchronize all ranks once before the training loop begins.
+        # This ensures every rank is ready before step 0, preventing NCCL
+        # deadlocks caused by ranks entering the loop at different times.
+        if dist.is_initialized():
+            dist.barrier()
+
         for step in range(self.global_step, cfg.total_steps):
             # DistributedOptimizer.zero_grad() zeroes its grad_data buffers +
             # shard param grads.  Plain AdamW zero_grad() on the non-ZeRO-3 path.
@@ -2271,14 +2277,10 @@ class DesLocEngine:
                             )
                             _dbg_rank = dist.get_rank() if dist.is_initialized() else 0
                             logger.info("rank=%d: before forward (step=%d micro=%d)", _dbg_rank, step, micro)
-                            if dist.is_initialized():
-                                dist.barrier()
                             with _offload_ctx:
                                 loss, scaled_loss = self.forward(
                                     input_ids, labels, num_microbatches=num_microbatches,
                                 )
-                            if dist.is_initialized():
-                                dist.barrier()
                             logger.info("rank=%d: after forward (step=%d micro=%d)", _dbg_rank, step, micro)
                             # Commit offload group: flush any pending D2H transfers
                             # for this micro-batch before backward begins.
@@ -2301,11 +2303,7 @@ class DesLocEngine:
                                     # the main-loss scale convention.
                                     scaled_loss = scaled_loss + _aux / max(num_microbatches, 1)
                             logger.info("rank=%d: before backward (step=%d micro=%d)", _dbg_rank, step, micro)
-                            if dist.is_initialized():
-                                dist.barrier()
                             scaled_loss.backward()
-                            if dist.is_initialized():
-                                dist.barrier()
                             logger.info("rank=%d: after backward (step=%d micro=%d)", _dbg_rank, step, micro)
                             # --- HeteroFP32GradAccumManager: accumulate (standard path) ---
                             # Promote BF16 param.grad into FP32 main_grad accumulators


### PR DESCRIPTION
## Problem

Training hangs at step 0. Rank 0 prints `rank=0: before forward (step=0 micro=0)` then deadlocks. Ranks 1 and 2 never print `[data]` at all — they are stuck in the data fetch while rank 0 has already advanced to a `dist.barrier()` in the hot path.

Because a `dist.barrier()` requires **all** ranks to arrive before any can proceed, and ranks 1/2 never arrive, the entire job hangs indefinitely.

## Root cause

Four debug `dist.barrier()` calls were left inside the per-microbatch forward/backward path (bracketing `self.forward(...)` and `scaled_loss.backward()`). These were never intended for production — they cause immediate deadlock whenever ranks reach the barrier at different times (which is always the case with heterogeneous data loading).

## Fix

1. **Remove all 4 hot-path barriers** — the `if dist.is_initialized(): dist.barrier()` guards before/after forward and before/after backward inside the `for micro` loop.
2. **Add one barrier before the training loop** — a single `dist.barrier()` before `for step in range(...)` so every rank is confirmed ready before step 0 begins.
3. **Confirmed safe** — `_apply_hetero_cp_slice` in `hetero_elastic_batch.py` is pure local tensor slicing with no NCCL collectives; it does not contribute to the hang.

## Files changed

- `deepspeed/runtime/desloc_engine.py`: −8 lines (4 barrier pairs removed), +6 lines (pre-loop barrier + comments)