### PR TITLE
bench(csrc): CUDA kernel benchmarks — addresses #83

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -48,6 +48,21 @@ foreach(bench hetero_reduce fused_swiglu_ln pcie_allreduce)
         CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES})
 endforeach()
 
+# ─── reduce-scatter vs naive baseline (issue #21) ────────────────────
+# Compares hetero_reduce_scatter_kernel against two naive single-GPU
+# baselines that model what non-fused NCCL reduce-scatter does on device.
+# Produces throughput (GB/s) and speedup numbers for each SM dispatch path.
+add_executable(bench_reduce_scatter_vs_naive
+    bench_reduce_scatter_vs_naive.cu)
+target_link_libraries(bench_reduce_scatter_vs_naive
+    PRIVATE hetero_kernels CUDA::cudart)
+target_include_directories(bench_reduce_scatter_vs_naive
+    PRIVATE ${HETERO_INCLUDE_DIRS})
+target_compile_options(bench_reduce_scatter_vs_naive PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:${CUDA_FLAGS}>)
+set_property(TARGET bench_reduce_scatter_vs_naive PROPERTY
+    CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES})
+
 # ─── NVTX profiling support (optional) ───────────────────────────────
 find_library(NVTX_LIB nvToolsExt PATHS ${CUDAToolkit_ROOT}/lib64)
 if(NVTX_LIB)

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,0 +1,26 @@
+# Makefile for bench_swiglu_ln
+#
+# Usage:
+#   make                    # default SM 8.6
+#   make SM=90              # target H100
+#   make SM=120             # target Blackwell
+#   make clean
+
+SM       ?= 86
+NVCC     ?= nvcc
+CXXFLAGS := -O3 -std=c++17 -arch=sm_$(SM) --use_fast_math
+INCLUDES := -I../csrc/includes -I../csrc/hetero_reduce
+
+FUSED_SRC := ../csrc/hetero_reduce/fused_swiglu_ln.cu
+BENCH_SRC := bench_swiglu_ln.cu
+TARGET    := bench_swiglu_ln
+
+.PHONY: all clean
+
+all: $(TARGET)
+
+$(TARGET): $(BENCH_SRC) $(FUSED_SRC)
+	$(NVCC) $(CXXFLAGS) $(INCLUDES) -o $@ $^
+
+clean:
+	rm -f $(TARGET)

--- a/benchmarks/README_bench_rs.md
+++ b/benchmarks/README_bench_rs.md
@@ -1,0 +1,200 @@
+# bench_reduce_scatter_vs_naive — Analysis & Results
+
+> Partially addresses [#21](https://github.com/dylanyunlon/Neuron_SP/issues/21)
+
+## What this benchmark measures
+
+`bench_reduce_scatter_vs_naive.cu` compares three implementations of the same
+reduce-scatter operation — reading N BF16 gradient tensors from device memory,
+element-wise summing them in FP32, and writing the result shard back as BF16:
+
+| Path | Description |
+|------|-------------|
+| `naive_serial_add` | Loop over tensors; one `cudaMemsetAsync` + N `naïve_accum_kernel` launches + 1 cast kernel. Models non-fused DDP. |
+| `naive_atomic_fp32` | Same loop but each thread uses `atomicAdd` into FP32 scratch. Models NCCL's per-chunk ring-reduce step. |
+| `hetero_fused` | Worker-12's `launch_hetero_reduce_scatter` — single fused kernel, 128-bit vectorised loads (`uint4`), SM-tuned launch bounds, constant-memory pointer array for ≤32 tensors. |
+
+The benchmark simulates a 5-tier heterogeneous cluster:
+- 2× A6000 (SM86, weight=1) + 1× H100 (SM90, weight=3) + 2× Blackwell (SM120, weight=4)
+- Total weight = 13; the H100 tier handles 3/13 ≈ 23% of gradient elements.
+
+---
+
+## Theoretical performance model
+
+### Memory traffic comparison
+
+For `shard_count` elements and `num_tensors` inputs:
+
+| Path | Read bytes | Write bytes | Total traffic |
+|------|-----------|-------------|---------------|
+| `naive_serial_add` | `nT × shard × 2` (input) + `(nT−1) × shard × 4` (RMW on fp32_buf) | `shard × 2` | ≈ `(3nT−1) × shard × 2` |
+| `naive_atomic_fp32` | `nT × shard × 2` (input) | `shard × (2+4)` | ≈ `(nT+1.5) × shard × 2` |
+| `hetero_fused` | `nT × shard × 2` (vectorised input) | `shard × 2` | `(nT+1) × shard × 2` |
+
+For `nT=8`:
+- `naive_serial_add` traffic ≈ `23× shard × 2`  
+- `hetero_fused` traffic ≈ `9× shard × 2`  
+- **Theoretical speedup (memory-bound): ~2.5×**
+
+---
+
+## Code analysis: what Worker-12's kernel does well
+
+### 1. `uint4` 128-bit vectorised loads (`bf16x8_accumulate`)
+
+```cuda
+const uint4 raw = *reinterpret_cast<const uint4*>(ptr);
+const __nv_bfloat162* p = reinterpret_cast<const __nv_bfloat162*>(&raw);
+// ... unrolled scalar-float accumulation
+```
+
+Each 128-bit load fetches 8 BF16 values in one memory transaction — the widest
+supported on SM86+. This minimises load instruction overhead and maximises L1/L2
+cache line utilisation.
+
+### 2. `uint4` 128-bit store (`fp32x8_store_bf16`)
+
+All 8 BF16 output values are packed into a single `uint4` and written with one
+128-bit store, matching the load granularity.
+
+### 3. `__constant__` memory pointer array
+
+For `num_tensors ≤ 32` (virtually all real cases), input pointers live in
+`__constant__` memory via `cudaMemcpyToSymbolAsync`. This avoids:
+- `cudaMallocAsync` on the launch critical path
+- Extra L2 pressure from device-memory pointer dereferences
+- The kernel only reads pointer values once per warp via broadcast
+
+### 4. Per-SM bucket sizing (KernelPolicy)
+
+| SM | L2 size | Bucket | Rationale |
+|----|---------|--------|-----------|
+| SM86 (A6000) | 6 MB | 4 MB | Keep gradient bucket inside L2 |
+| SM90 (H100) | 50 MB | 32 MB | Entire bucket fits in L2 → zero DRAM re-reads |
+| SM120 (Blackwell) | 40 MB | 16 MB | Moderate; avoids thrash |
+
+This is a genuine algorithmic win: the H100 gets 32 MB buckets that live
+entirely in its 50 MB L2, so each BF16 element is read **once** from DRAM
+and accumulated entirely in L2.
+
+### 5. `#pragma unroll 4` on the tensor loop
+
+Reduces branch prediction overhead and gives the compiler room to software-
+pipeline loads from different tensors (latency hiding for memory-bound kernels).
+
+---
+
+## Issues found during analysis
+
+### Issue A: Bug in `dispatch_reduce_scatter` warp-coop grid sizing
+
+```cuda
+// csrc/hetero_reduce/hetero_reduce.cu  line ~490
+const int warps_needed = (int)std::min(
+    (vec_count + 1 - 1) / 1, (size_t)65535);   // ← (N+0)/1 == N, always
+const int grid = (warps_needed * hw_warp_size + 255) / 256;
+```
+
+`(vec_count + 1 - 1) / 1` simplifies to `vec_count` — the `+ 1 - 1` is a
+vestigial rounding idiom that achieves nothing when the divisor is `1`.
+
+**Impact:** For small shards the grid is massively over-provisioned. If
+`shard_count = 128K` and `kVec = 8`, `vec_count = 16384`, `warps_needed =
+16384`, `grid = 2048` — but we only need `ceil(16384 / (256/32)) = 2048`
+total warps → `grid = 256`. Wait — actually these numbers happen to be the
+same. The bug is latent and only manifests if the intent was to limit warps
+by some other factor (e.g. `warps_per_output_vec`). Needs clarification
+from Worker-12 before patching.
+
+**Recommendation:** Add an assertion `warps_needed == (vec_count)` or
+document the intended invariant.
+
+### Issue B: warp-coop path `shard_count ≤ kSmallThresh` uses constant 128K
+
+```cuda
+constexpr size_t kSmallThresh = 128UL * 1024UL;  // 128K elements
+```
+
+The threshold is the same for all SM versions, but the optimal crossover
+between warp-coop and the main vectorised path depends on the number of
+active warps per SM (`kMinBlocksPerSM × kBlockSize / 32`). For SM120
+(512 threads/block, 4 blocks/SM → 64 warps/SM), the warp-coop path may
+underperform because the main path saturates memory bus with more warps.
+
+**Recommendation:** Make `kSmallThresh` part of `KernelPolicy<SmVer>`.
+
+### Issue C: FP32 scratch not pre-zeroed in the kernel
+
+`hetero_reduce_scatter_kernel` writes directly to `output` (no separate FP32
+scratch buffer), which is correct. But both naive baselines need a pre-zeroed
+FP32 buffer, adding a `cudaMemsetAsync` to every launch. The benchmark
+accounts for this in the timing loop.
+
+---
+
+## How to build & run
+
+```bash
+# From repo root, requires nvcc + SM86/90/120 GPU
+cd benchmarks
+mkdir -p build && cd build
+cmake .. -DCMAKE_CUDA_ARCHITECTURES="86;90;120"
+make -j$(nproc) bench_reduce_scatter_vs_naive
+
+# Run on current GPU (SM autodetected)
+./bench_reduce_scatter_vs_naive
+
+# Force SM90 dispatch path (H100 tuning)
+./bench_reduce_scatter_vs_naive --sm 90
+
+# CI regression gate (exits 0 if fused kernel ≥1.3× faster for large shards)
+./bench_reduce_scatter_vs_naive --regression
+
+# Quick run
+./bench_reduce_scatter_vs_naive --warmup 5 --iters 20
+```
+
+---
+
+## Expected output shape (representative H100 numbers — run on real GPU)
+
+```
+═══════════════════════════════════════════════════════════════
+  bench_reduce_scatter_vs_naive  (issue #21)
+═══════════════════════════════════════════════════════════════
+  Device : NVIDIA H100 SXM5  (SM 9.0, 132 SMs)
+  Dispatch SM path : SM90
+  Peak HBM BW (est): 3350 GB/s
+  Warmup: 20   Iters: 80
+═══════════════════════════════════════════════════════════════
+
+Correctness check ... PASS ✓
+
+config                            path                     min_µs   avg_µs    rd_GB/s  eff_GB/s  speedup
+────────────────────────────────────────────────────────────────────────────────────────────────────────────
+n=4M  nT=4  shard=923K           naive_serial_add           xxx.x    xxx.x      xxx.x     xxx.x    1.00x
+n=4M  nT=4  shard=923K           naive_atomic_fp32          xxx.x    xxx.x      xxx.x     xxx.x    x.xxX
+n=4M  nT=4  shard=923K           hetero_fused               xxx.x    xxx.x      xxx.x     xxx.x    x.xxX
+
+n=16M  nT=8  shard=3.7M          naive_serial_add           xxx.x    xxx.x      xxx.x     xxx.x    1.00x
+n=16M  nT=8  shard=3.7M          naive_atomic_fp32          xxx.x    xxx.x      xxx.x     xxx.x    x.xxX
+n=16M  nT=8  shard=3.7M          hetero_fused               xxx.x    xxx.x      xxx.x     xxx.x    x.xxX
+...
+
+─── Speedup summary (hetero_fused vs naive_serial_add) ─────────
+  n=16M  nT=8  shard=3.7M         xxx.x     ~2.5x  (expected from memory model)
+  n=64M  nT=16 shard=14.8M        xxx.x     ~2.8x
+```
+
+*Actual numbers require running on a physical GPU. The `x.xx` placeholders
+will be filled in when this PR is run against real hardware in CI.*
+
+---
+
+## Next steps (separate PRs)
+
+1. Fix Issue A: clarify or correct warp-coop grid sizing in `dispatch_reduce_scatter`
+2. Fix Issue B: add `kSmallThresh` to `KernelPolicy<SmVer>` per-arch
+3. Consider adding `__ldg()` read-only cache hints to `bf16x8_accumulate` inputs
+   (may help on SM86 with limited L1 cache)

--- a/benchmarks/bench_hetero_reduce_vs_naive.cu
+++ b/benchmarks/bench_hetero_reduce_vs_naive.cu
@@ -1,0 +1,311 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0
+
+// DeepSpeed Team
+
+/*
+ * bench_hetero_reduce_vs_naive.cu
+ *
+ * Comparative benchmark: hetero_reduce_scatter_kernel (fused vectorised,
+ * policy-driven) vs a naive scalar baseline.
+ *
+ * Purpose:
+ *   Quantify the throughput gain from the algorithmic innovations in
+ *   hetero_reduce.cu (vectorised BF16x8 loads, __constant__ pointer
+ *   array, warp-cooperative small-tensor path, per-SM-tier policy).
+ *
+ * Methodology:
+ *   - Naive baseline: one thread per output element, scalar BF16→FP32
+ *     accumulation, no vectorisation, pointer array in device memory.
+ *   - Fused kernel: launch_hetero_reduce_scatter() from the production
+ *     API (auto-selects warp-coop vs standard path).
+ *   - Each configuration runs 5 warmup + 20 timed iterations; reports
+ *     median latency and effective memory bandwidth.
+ *   - Correctness is verified per-config (relative tolerance 1%).
+ *
+ * Compile:
+ *   nvcc -O3 -std=c++17 -arch=sm_86 \
+ *        -I../csrc/includes -I../csrc/hetero_reduce \
+ *        bench_hetero_reduce_vs_naive.cu \
+ *        ../csrc/hetero_reduce/hetero_reduce.cu \
+ *        -o bench_hetero_reduce_vs_naive
+ *
+ * Run:
+ *   ./bench_hetero_reduce_vs_naive [sm_version]
+ *   # sm_version defaults to auto-detect from current device
+ */
+
+#include <cuda.h>
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <vector>
+#include <algorithm>
+
+#include "hetero_reduce.h"
+
+// ──────────────────────────────────────────────────────────────────────
+// Error checking
+// ──────────────────────────────────────────────────────────────────────
+
+#define CUDA_CHECK(call)                                                   \
+    do {                                                                    \
+        cudaError_t _e = (call);                                            \
+        if (_e != cudaSuccess) {                                            \
+            fprintf(stderr, "CUDA error %s:%d: %s\n", __FILE__, __LINE__,  \
+                    cudaGetErrorString(_e));                                 \
+            exit(1);                                                        \
+        }                                                                   \
+    } while (0)
+
+// ──────────────────────────────────────────────────────────────────────
+// Device query
+// ──────────────────────────────────────────────────────────────────────
+
+static int detect_sm_version() {
+    int dev = 0;
+    CUDA_CHECK(cudaGetDevice(&dev));
+    cudaDeviceProp prop;
+    CUDA_CHECK(cudaGetDeviceProperties(&prop, dev));
+    return prop.major * 10 + prop.minor;
+}
+
+static void print_device_info() {
+    int dev = 0;
+    CUDA_CHECK(cudaGetDevice(&dev));
+    cudaDeviceProp prop;
+    CUDA_CHECK(cudaGetDeviceProperties(&prop, dev));
+    printf("  Device:     %s\n", prop.name);
+    printf("  SM count:   %d\n", prop.multiProcessorCount);
+    printf("  L2 cache:   %.1f MB\n", prop.l2CacheSize / (1024.0 * 1024.0));
+    printf("  Mem BW:     %.0f GB/s (theoretical peak)\n",
+           2.0 * prop.memoryClockRate * (prop.memoryBusWidth / 8) / 1e6);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Data initialisation
+// ──────────────────────────────────────────────────────────────────────
+
+static void fill_random_bf16(__nv_bfloat16* d_ptr, size_t n, unsigned seed) {
+    std::vector<__nv_bfloat16> host(n);
+    srand(seed);
+    for (size_t i = 0; i < n; ++i)
+        host[i] = __float2bfloat16(((float)rand() / RAND_MAX - 0.5f) * 2.0f);
+    CUDA_CHECK(cudaMemcpy(d_ptr, host.data(), n * sizeof(__nv_bfloat16),
+                           cudaMemcpyHostToDevice));
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Naive baseline kernel
+//
+// One thread per output element.  Scalar loads, no vectorisation,
+// pointer array in device memory.  This is the simplest correct
+// implementation — it establishes the performance floor.
+// ──────────────────────────────────────────────────────────────────────
+
+__global__ void naive_reduce_scatter_kernel(
+    __nv_bfloat16* __restrict__              output,
+    const __nv_bfloat16* const* __restrict__ d_inputs,
+    int    num_tensors,
+    size_t shard_offset,
+    size_t shard_count)
+{
+    const size_t idx = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= shard_count) return;
+
+    float acc = 0.f;
+    const size_t gidx = shard_offset + idx;
+    for (int t = 0; t < num_tensors; ++t)
+        acc += __bfloat162float(d_inputs[t][gidx]);
+    output[idx] = __float2bfloat16(acc);
+}
+
+static void launch_naive(
+    __nv_bfloat16* output,
+    const __nv_bfloat16* const* h_inputs,
+    int num_tensors,
+    size_t shard_offset,
+    size_t shard_count,
+    cudaStream_t stream)
+{
+    const __nv_bfloat16** d_ptrs = nullptr;
+    CUDA_CHECK(cudaMallocAsync(reinterpret_cast<void**>(&d_ptrs),
+               num_tensors * sizeof(const __nv_bfloat16*), stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_ptrs, h_inputs,
+               num_tensors * sizeof(const __nv_bfloat16*),
+               cudaMemcpyHostToDevice, stream));
+
+    constexpr int kBlock = 256;
+    const int grid = (int)std::min(
+        (shard_count + kBlock - 1) / kBlock, (size_t)65535);
+    naive_reduce_scatter_kernel<<<grid, kBlock, 0, stream>>>(
+        output, d_ptrs, num_tensors, shard_offset, shard_count);
+
+    CUDA_CHECK(cudaFreeAsync(d_ptrs, stream));
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Correctness verification
+// ──────────────────────────────────────────────────────────────────────
+
+static bool verify(
+    __nv_bfloat16* d_ref, __nv_bfloat16* d_test, size_t n,
+    float rtol = 1e-2f)
+{
+    std::vector<__nv_bfloat16> h_ref(n), h_test(n);
+    CUDA_CHECK(cudaMemcpy(h_ref.data(), d_ref, n * sizeof(__nv_bfloat16),
+                           cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_test.data(), d_test, n * sizeof(__nv_bfloat16),
+                           cudaMemcpyDeviceToHost));
+    int bad = 0;
+    for (size_t i = 0; i < n && bad < 5; ++i) {
+        float a = __bfloat162float(h_ref[i]);
+        float b = __bfloat162float(h_test[i]);
+        float diff = fabsf(a - b);
+        float denom = fmaxf(fabsf(a), 1e-6f);
+        if (diff / denom > rtol) {
+            if (bad == 0)
+                fprintf(stderr, "    mismatch [%zu]: ref=%.6f got=%.6f\n",
+                        i, a, b);
+            ++bad;
+        }
+    }
+    return bad == 0;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Timing: returns median of N runs in milliseconds
+// ──────────────────────────────────────────────────────────────────────
+
+template <typename Fn>
+static float time_median(Fn fn, cudaStream_t stream,
+                         int warmup = 5, int iters = 20)
+{
+    for (int i = 0; i < warmup; ++i) fn();
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+
+    std::vector<float> times(iters);
+    cudaEvent_t t0, t1;
+    CUDA_CHECK(cudaEventCreate(&t0));
+    CUDA_CHECK(cudaEventCreate(&t1));
+
+    for (int i = 0; i < iters; ++i) {
+        CUDA_CHECK(cudaEventRecord(t0, stream));
+        fn();
+        CUDA_CHECK(cudaEventRecord(t1, stream));
+        CUDA_CHECK(cudaEventSynchronize(t1));
+        CUDA_CHECK(cudaEventElapsedTime(&times[i], t0, t1));
+    }
+    CUDA_CHECK(cudaEventDestroy(t0));
+    CUDA_CHECK(cudaEventDestroy(t1));
+
+    std::sort(times.begin(), times.end());
+    return times[iters / 2];
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Main benchmark loop
+// ──────────────────────────────────────────────────────────────────────
+
+int main(int argc, char** argv) {
+    int sm = (argc >= 2) ? atoi(argv[1]) : detect_sm_version();
+
+    printf("═══════════════════════════════════════════════════════════════════\n");
+    printf("  hetero_reduce_scatter: fused kernel vs naive baseline\n");
+    printf("  SM version (dispatch): %d\n", sm);
+    print_device_info();
+    printf("═══════════════════════════════════════════════════════════════════\n\n");
+
+    cudaStream_t stream;
+    CUDA_CHECK(cudaStreamCreate(&stream));
+
+    // ── Test matrix ──────────────────────────────────────────────────
+    struct Config {
+        int    num_tensors;
+        size_t shard_count;
+        const char* tag;
+    };
+
+    Config cfgs[] = {
+        // Small (warp-coop path)
+        { 4,   64UL * 1024,          " 4T x   64K" },
+        { 8,   64UL * 1024,          " 8T x   64K" },
+        { 16,  64UL * 1024,          "16T x   64K" },
+        // Medium (standard vectorised path)
+        { 4,  512UL * 1024,          " 4T x  512K" },
+        { 8,  512UL * 1024,          " 8T x  512K" },
+        { 16, 512UL * 1024,          "16T x  512K" },
+        // Large (bandwidth-bound)
+        { 4,  4UL * 1024 * 1024,     " 4T x    4M" },
+        { 8,  4UL * 1024 * 1024,     " 8T x    4M" },
+        { 16, 4UL * 1024 * 1024,     "16T x    4M" },
+        // XL stress
+        { 4,  16UL * 1024 * 1024,    " 4T x   16M" },
+        { 8,  16UL * 1024 * 1024,    " 8T x   16M" },
+    };
+    const int N = sizeof(cfgs) / sizeof(cfgs[0]);
+
+    printf("%-14s  %9s  %9s  %8s  %10s  %10s  %5s\n",
+           "Config", "Naive(ms)", "Fused(ms)", "Speedup",
+           "Naive GB/s", "Fused GB/s", "Check");
+    printf("─────────────────────────────────────────────────────"
+           "─────────────────────────────────\n");
+
+    for (int ci = 0; ci < N; ++ci) {
+        const auto& c = cfgs[ci];
+
+        // Allocate inputs
+        std::vector<__nv_bfloat16*> d_in(c.num_tensors);
+        std::vector<const __nv_bfloat16*> h_ptrs(c.num_tensors);
+        for (int t = 0; t < c.num_tensors; ++t) {
+            CUDA_CHECK(cudaMalloc(&d_in[t],
+                       c.shard_count * sizeof(__nv_bfloat16)));
+            fill_random_bf16(d_in[t], c.shard_count, 42 + t);
+            h_ptrs[t] = d_in[t];
+        }
+
+        __nv_bfloat16 *d_naive = nullptr, *d_fused = nullptr;
+        CUDA_CHECK(cudaMalloc(&d_naive, c.shard_count * sizeof(__nv_bfloat16)));
+        CUDA_CHECK(cudaMalloc(&d_fused, c.shard_count * sizeof(__nv_bfloat16)));
+
+        // Total bytes moved: num_tensors reads + 1 write, all in BF16
+        const double total_bytes =
+            (double)(c.num_tensors + 1) * c.shard_count * sizeof(__nv_bfloat16);
+
+        // Time naive
+        float ms_naive = time_median([&]() {
+            launch_naive(d_naive, h_ptrs.data(), c.num_tensors,
+                         0, c.shard_count, stream);
+        }, stream);
+
+        // Time fused
+        float ms_fused = time_median([&]() {
+            launch_hetero_reduce_scatter(
+                d_fused, h_ptrs.data(), c.num_tensors,
+                0, c.shard_count, sm, stream);
+        }, stream);
+
+        CUDA_CHECK(cudaStreamSynchronize(stream));
+        bool ok = verify(d_naive, d_fused, c.shard_count);
+
+        float speedup   = ms_naive / ms_fused;
+        float bw_naive  = (float)(total_bytes / (ms_naive * 1e6));
+        float bw_fused  = (float)(total_bytes / (ms_fused * 1e6));
+
+        printf("%-14s  %9.3f  %9.3f  %7.2fx  %9.1f  %9.1f  %5s\n",
+               c.tag, ms_naive, ms_fused, speedup,
+               bw_naive, bw_fused,
+               ok ? "OK" : "FAIL");
+
+        for (int t = 0; t < c.num_tensors; ++t)
+            CUDA_CHECK(cudaFree(d_in[t]));
+        CUDA_CHECK(cudaFree(d_naive));
+        CUDA_CHECK(cudaFree(d_fused));
+    }
+
+    printf("\n");
+    CUDA_CHECK(cudaStreamDestroy(stream));
+    return 0;
+}

--- a/benchmarks/bench_reduce_scatter_vs_naive.cu
+++ b/benchmarks/bench_reduce_scatter_vs_naive.cu
@@ -1,0 +1,707 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0
+
+// DeepSpeed Team — Claude-W1 (issue #21)
+
+/*
+ * bench_reduce_scatter_vs_naive.cu
+ *
+ * Throughput benchmark: fused hetero_reduce_scatter_kernel vs two naive
+ * single-GPU baselines that approximate what NCCL reduce-scatter would do
+ * on a PCIe-only cluster.
+ *
+ * ─── What are we measuring? ─────────────────────────────────────────────
+ *
+ * In a PCIe heterogeneous cluster running reduce-scatter, each GPU must:
+ *   (a) READ  all `num_tensors` input gradient shards (the local copies
+ *       each worker sent via PCIe — already in device memory by the time
+ *       the kernel fires).
+ *   (b) SUM   them element-wise in FP32 (to avoid BF16 rounding error
+ *       accumulation over many workers).
+ *   (c) WRITE the BF16 result to its assigned output shard.
+ *
+ * The "fused" kernel does (a)+(b)+(c) in one pass with FP32 accumulators,
+ * 128-bit vectorised loads (uint4), and SM-tuned launch bounds.
+ *
+ * The two naive baselines do the same work but less efficiently:
+ *
+ *   Naive-A (serial-add):
+ *     For each tensor t:  output[i] += (float)input_t[i]    (loop, no fuse)
+ *     output[i] = (bf16)output[i]
+ *     This needs num_tensors kernel launches and reads output (num_tensors-1)
+ *     extra times (read-modify-write each iter).
+ *
+ *   Naive-B (atomic-scatter):
+ *     Atomically accumulates into a FP32 scratch buffer, then casts to BF16.
+ *     Models NCCL's internal reduce path; one kernel per tensor but with
+ *     atomicAdd contention on the output.
+ *
+ * ─── Performance model ──────────────────────────────────────────────────
+ *
+ * Fused kernel "effective bytes" = num_tensors × shard_bytes (read)
+ *                                + shard_bytes (write)
+ * Naive-A  "effective bytes"     = num_tensors × 2 × shard_bytes (read+write each)
+ *                                + shard_bytes (final write)
+ *                  ≈ (2×num_tensors + 1) × shard_bytes
+ *
+ * So even without any algorithmic improvement, the fused kernel should show
+ * roughly 2× lower byte traffic for num_tensors ≥ 4, and thus 2× throughput
+ * vs Naive-A if memory-bound.
+ *
+ * ─── Compile ────────────────────────────────────────────────────────────
+ *   # From repo root:
+ *   nvcc -O3 -arch=sm_90 -std=c++20 \
+ *     -I csrc/hetero_reduce -I csrc/includes \
+ *     benchmarks/bench_reduce_scatter_vs_naive.cu \
+ *     csrc/hetero_reduce/hetero_reduce.cu \
+ *     -o bench_reduce_scatter_vs_naive
+ *
+ *   # Or via CMake (add to benchmarks/CMakeLists.txt):
+ *   #   add_executable(bench_rs_naive benchmarks/bench_reduce_scatter_vs_naive.cu)
+ *   #   target_link_libraries(bench_rs_naive PRIVATE hetero_kernels CUDA::cudart)
+ *
+ * ─── Run ────────────────────────────────────────────────────────────────
+ *   ./bench_reduce_scatter_vs_naive
+ *   ./bench_reduce_scatter_vs_naive --sm 86
+ *   ./bench_reduce_scatter_vs_naive --iters 100 --warmup 20
+ *
+ * ─── Sample output (H100 SXM5, SM90) ───────────────────────────────────
+ *
+ *  config                          path               min_us  avg_us   GB/s  speedup
+ *  ─────────────────────────────────────────────────────────────────────────────────
+ *  n=4M  nT=4  shard=1M           naive_serial_add   xxx.x   xxx.x    xxx    1.00x
+ *  n=4M  nT=4  shard=1M           naive_atomic_fp32  xxx.x   xxx.x    xxx    x.xxX
+ *  n=4M  nT=4  shard=1M           hetero_fused       xxx.x   xxx.x    xxx    x.xxX
+ *  ...
+ *
+ *  (Actual numbers require a real GPU — this file compiles and links cleanly.)
+ *
+ * Partially addresses #21.
+ */
+
+#include <cuda.h>
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+// Kernel + API declarations from Worker-12's implementation
+#include "../csrc/hetero_reduce/hetero_reduce.h"
+// Provides DS_D_INLINE, hw_warp_size
+#include "../csrc/includes/ds_kernel_utils.h"
+
+namespace cg = cooperative_groups;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §1  Error-checking helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+#define CUDA_CHECK(expr)                                                     \
+    do {                                                                     \
+        cudaError_t _e = (expr);                                             \
+        if (_e != cudaSuccess) {                                             \
+            fprintf(stderr, "CUDA error %s:%d  %s\n",                       \
+                    __FILE__, __LINE__, cudaGetErrorString(_e));             \
+            exit(1);                                                         \
+        }                                                                    \
+    } while (0)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §2  GPU event timer
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct GpuTimer {
+    cudaEvent_t start_, stop_;
+    GpuTimer() {
+        CUDA_CHECK(cudaEventCreate(&start_));
+        CUDA_CHECK(cudaEventCreate(&stop_));
+    }
+    ~GpuTimer() {
+        cudaEventDestroy(start_);
+        cudaEventDestroy(stop_);
+    }
+    void start(cudaStream_t s) { CUDA_CHECK(cudaEventRecord(start_, s)); }
+    float stop_ms(cudaStream_t s) {
+        CUDA_CHECK(cudaEventRecord(stop_, s));
+        CUDA_CHECK(cudaEventSynchronize(stop_));
+        float ms = 0.f;
+        CUDA_CHECK(cudaEventElapsedTime(&ms, start_, stop_));
+        return ms;
+    }
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §3  Naive baseline kernels
+//
+//   These model what a non-fused NCCL reduce-scatter equivalent does on device
+//   after PCIe transfers have placed all gradient copies in VRAM.
+//
+//   Naive-A: serial add
+//     Each "step" kernel: output[i] += bf162float(input_t[i])
+//     Final "cast" kernel: output[i] = float2bf16(fp32_accum[i])
+//
+//   Naive-B: atomic scatter
+//     All tensors launch in parallel; each thread does atomicAdd into an FP32
+//     accumulator.  This is closer to what ring-allreduce does internally per
+//     chunk.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Naive-A step: accumulate one BF16 input tensor into a FP32 buffer.
+// launch config: grid×block covers [shard_offset, shard_offset+shard_count)
+__global__ void naive_accum_kernel(
+    float*       __restrict__ fp32_buf,      // [shard_count]
+    const __nv_bfloat16* __restrict__ input, // full tensor [total_elems]
+    size_t shard_offset,
+    size_t shard_count)
+{
+    const size_t tid    = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
+    const size_t stride = (size_t)gridDim.x  * blockDim.x;
+    for (size_t i = tid; i < shard_count; i += stride) {
+        fp32_buf[i] += __bfloat162float(input[shard_offset + i]);
+    }
+}
+
+// Naive-A cast: FP32 accumulator → BF16 output
+__global__ void naive_cast_kernel(
+    __nv_bfloat16* __restrict__ output,
+    const float*   __restrict__ fp32_buf,
+    size_t shard_count)
+{
+    const size_t tid    = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
+    const size_t stride = (size_t)gridDim.x  * blockDim.x;
+    for (size_t i = tid; i < shard_count; i += stride) {
+        output[i] = __float2bfloat16(fp32_buf[i]);
+    }
+}
+
+// Naive-B: atomic scatter — every tensor concurrently atomicAdds into FP32.
+// Each kernel covers [shard_offset, shard_offset+shard_count).
+__global__ void naive_atomic_accum_kernel(
+    float*       __restrict__ fp32_buf,
+    const __nv_bfloat16* __restrict__ input,
+    size_t shard_offset,
+    size_t shard_count)
+{
+    const size_t tid    = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
+    const size_t stride = (size_t)gridDim.x  * blockDim.x;
+    for (size_t i = tid; i < shard_count; i += stride) {
+        atomicAdd(&fp32_buf[i], __bfloat162float(input[shard_offset + i]));
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §4  Launch wrappers for naive baselines
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Common launch config: threads=256, grid capped at 65535.
+static constexpr int kNaiveBlock = 256;
+
+static int naive_grid(size_t n) {
+    return (int)std::min((n + kNaiveBlock - 1) / kNaiveBlock, (size_t)65535);
+}
+
+// Naive-A: serial per-tensor accumulation then FP32→BF16 cast.
+// Allocates a temporary FP32 buffer on the fly (matches real usage).
+static void launch_naive_serial_add(
+    __nv_bfloat16*              output,
+    const __nv_bfloat16* const* inputs,
+    int                         num_tensors,
+    size_t                      shard_offset,
+    size_t                      shard_count,
+    float*                      d_fp32_tmp,   // pre-allocated scratch [shard_count]
+    cudaStream_t                stream)
+{
+    // Zero accumulator
+    CUDA_CHECK(cudaMemsetAsync(d_fp32_tmp, 0, shard_count * sizeof(float), stream));
+
+    const int grid = naive_grid(shard_count);
+
+    // Accumulate each tensor serially (num_tensors kernel launches)
+    for (int t = 0; t < num_tensors; ++t) {
+        naive_accum_kernel<<<grid, kNaiveBlock, 0, stream>>>(
+            d_fp32_tmp, inputs[t], shard_offset, shard_count);
+    }
+
+    // Final BF16 cast
+    naive_cast_kernel<<<grid, kNaiveBlock, 0, stream>>>(
+        output, d_fp32_tmp, shard_count);
+}
+
+// Naive-B: concurrent atomic accumulation (one launch per tensor, all in the
+// same stream so they don't truly overlap, but atomics model contention).
+static void launch_naive_atomic(
+    __nv_bfloat16*              output,
+    const __nv_bfloat16* const* inputs,
+    int                         num_tensors,
+    size_t                      shard_offset,
+    size_t                      shard_count,
+    float*                      d_fp32_tmp,
+    cudaStream_t                stream)
+{
+    CUDA_CHECK(cudaMemsetAsync(d_fp32_tmp, 0, shard_count * sizeof(float), stream));
+
+    const int grid = naive_grid(shard_count);
+
+    for (int t = 0; t < num_tensors; ++t) {
+        naive_atomic_accum_kernel<<<grid, kNaiveBlock, 0, stream>>>(
+            d_fp32_tmp, inputs[t], shard_offset, shard_count);
+    }
+    naive_cast_kernel<<<grid, kNaiveBlock, 0, stream>>>(
+        output, d_fp32_tmp, shard_count);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §5  Correctness verification
+//
+//   Reduce 3 BF16 tensors of known values using each path; check outputs match.
+//   Uses values chosen so BF16 rounding is deterministic.
+// ─────────────────────────────────────────────────────────────────────────────
+
+static bool verify_correctness(int sm_version, cudaStream_t stream)
+{
+    constexpr size_t N = 4096;
+    constexpr int    T = 4;
+    constexpr float  VAL = 0.5f;   // 4 × 0.5 = 2.0 — representable exactly in BF16
+
+    __nv_bfloat16* d_out_fused  = nullptr;
+    __nv_bfloat16* d_out_serial = nullptr;
+    __nv_bfloat16* d_in[T]      = {};
+    float*         d_fp32       = nullptr;
+
+    CUDA_CHECK(cudaMalloc(&d_out_fused,  N * sizeof(__nv_bfloat16)));
+    CUDA_CHECK(cudaMalloc(&d_out_serial, N * sizeof(__nv_bfloat16)));
+    CUDA_CHECK(cudaMalloc(&d_fp32,       N * sizeof(float)));
+
+    std::vector<__nv_bfloat16> h_in(N, __float2bfloat16(VAL));
+    for (int t = 0; t < T; ++t) {
+        CUDA_CHECK(cudaMalloc(&d_in[t], N * sizeof(__nv_bfloat16)));
+        CUDA_CHECK(cudaMemcpy(d_in[t], h_in.data(), N * sizeof(__nv_bfloat16),
+                              cudaMemcpyHostToDevice));
+    }
+    std::vector<const __nv_bfloat16*> ptrs(T);
+    for (int t = 0; t < T; ++t) ptrs[t] = d_in[t];
+
+    // Fused kernel (shard_offset=0, shard_count=N → full tensor)
+    launch_hetero_reduce_scatter(d_out_fused, ptrs.data(), T,
+                                 /*shard_offset=*/0, N, sm_version, stream);
+
+    // Naive serial add (same shard)
+    launch_naive_serial_add(d_out_serial, ptrs.data(), T,
+                            0, N, d_fp32, stream);
+
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+
+    // Host-side check
+    std::vector<__nv_bfloat16> h_fused(N), h_serial(N);
+    CUDA_CHECK(cudaMemcpy(h_fused.data(),  d_out_fused,  N * sizeof(__nv_bfloat16),
+                          cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_serial.data(), d_out_serial, N * sizeof(__nv_bfloat16),
+                          cudaMemcpyDeviceToHost));
+
+    const float expected = T * VAL;  // 2.0f
+    bool ok = true;
+    for (size_t i = 0; i < N; ++i) {
+        float vf = __bfloat162float(h_fused[i]);
+        float vs = __bfloat162float(h_serial[i]);
+        if (std::abs(vf - expected) > 0.02f) {
+            fprintf(stderr, "[FAIL] fused[%zu] = %.4f, expected %.4f\n", i, vf, expected);
+            ok = false; break;
+        }
+        if (std::abs(vs - expected) > 0.02f) {
+            fprintf(stderr, "[FAIL] serial[%zu] = %.4f, expected %.4f\n", i, vs, expected);
+            ok = false; break;
+        }
+    }
+
+    CUDA_CHECK(cudaFree(d_out_fused));
+    CUDA_CHECK(cudaFree(d_out_serial));
+    CUDA_CHECK(cudaFree(d_fp32));
+    for (int t = 0; t < T; ++t) CUDA_CHECK(cudaFree(d_in[t]));
+    return ok;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §6  Benchmark result types
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct RSResult {
+    const char* config_tag;    // e.g. "n=16M  nT=8  shard=2M"
+    const char* path;          // "naive_serial_add" | "naive_atomic_fp32" | "hetero_fused"
+    size_t      total_elems;
+    size_t      shard_count;
+    int         num_tensors;
+    int         sm_version;
+    float       min_us;
+    float       avg_us;
+    float       bw_read_gbs;   // num_tensors × shard_bytes / latency  (read BW)
+    float       bw_eff_gbs;    // (num_tensors × shard_bytes + shard_bytes) / latency
+    float       speedup;       // relative to naive_serial_add for this config
+};
+
+static void print_header_rs()
+{
+    printf("\n%-32s  %-22s  %8s  %8s  %10s  %10s  %7s\n",
+           "config", "path", "min_µs", "avg_µs",
+           "rd_GB/s", "eff_GB/s", "speedup");
+    printf("%s\n", std::string(108, '─').c_str());
+}
+
+static void print_rs(const RSResult& r)
+{
+    printf("%-32s  %-22s  %8.1f  %8.1f  %10.1f  %10.1f  %6.2fx\n",
+           r.config_tag, r.path,
+           r.min_us, r.avg_us,
+           r.bw_read_gbs, r.bw_eff_gbs,
+           r.speedup);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §7  Per-config benchmark driver
+// ─────────────────────────────────────────────────────────────────────────────
+
+static constexpr int kWarmup = 20;
+static constexpr int kIter   = 80;
+
+struct ConfigResult {
+    RSResult serial_add;
+    RSResult atomic_fp32;
+    RSResult hetero_fused;
+};
+
+// Collect min + mean over kIter iterations.
+static std::pair<float,float> bench_fn(
+    std::function<void()> fn,
+    cudaStream_t          stream)
+{
+    GpuTimer timer;
+    // Warmup
+    for (int i = 0; i < kWarmup; ++i) fn();
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+
+    float total = 0.f, mn = 1e9f;
+    for (int i = 0; i < kIter; ++i) {
+        timer.start(stream);
+        fn();
+        float ms = timer.stop_ms(stream);
+        total += ms;
+        mn = std::min(mn, ms);
+    }
+    return {mn * 1000.f, (total / kIter) * 1000.f};  // → µs
+}
+
+static ConfigResult bench_config(
+    size_t      total_elems,
+    size_t      shard_offset,
+    size_t      shard_count,
+    int         num_tensors,
+    int         sm_version,
+    cudaStream_t stream,
+    char*       config_tag_buf)
+{
+    // Build config tag string
+    const float shard_mb = shard_count * 2.f / (1 << 20);
+    const float total_mb = total_elems  * 2.f / (1 << 20);
+    snprintf(config_tag_buf, 64,
+             "n=%.0fM  nT=%d  shard=%.0fM",
+             total_mb, num_tensors, shard_mb);
+
+    // Allocate inputs (full tensor each)
+    std::vector<__nv_bfloat16*> d_in(num_tensors, nullptr);
+    for (int t = 0; t < num_tensors; ++t) {
+        CUDA_CHECK(cudaMalloc(&d_in[t], total_elems * sizeof(__nv_bfloat16)));
+        CUDA_CHECK(cudaMemset(d_in[t], 0x3c, total_elems * sizeof(__nv_bfloat16)));
+    }
+    std::vector<const __nv_bfloat16*> ptrs(num_tensors);
+    for (int t = 0; t < num_tensors; ++t) ptrs[t] = d_in[t];
+
+    // Allocate outputs and scratch
+    __nv_bfloat16* d_out_serial = nullptr;
+    __nv_bfloat16* d_out_atomic = nullptr;
+    __nv_bfloat16* d_out_fused  = nullptr;
+    float*         d_fp32       = nullptr;
+    CUDA_CHECK(cudaMalloc(&d_out_serial, shard_count * sizeof(__nv_bfloat16)));
+    CUDA_CHECK(cudaMalloc(&d_out_atomic, shard_count * sizeof(__nv_bfloat16)));
+    CUDA_CHECK(cudaMalloc(&d_out_fused,  shard_count * sizeof(__nv_bfloat16)));
+    CUDA_CHECK(cudaMalloc(&d_fp32,       shard_count * sizeof(float)));
+
+    // Bandwidth accounting
+    // Read: num_tensors × shard_count × 2 (BF16 from full tensors, but only shard slice)
+    // Write: shard_count × 2 (BF16 output)
+    const float read_bytes  = (float)((size_t)num_tensors * shard_count * 2);
+    const float write_bytes = (float)(shard_count * 2);
+    const float eff_bytes   = read_bytes + write_bytes;
+
+    auto bw_rd  = [&](float us) { return (read_bytes / 1e9f) / (us / 1e6f); };
+    auto bw_eff = [&](float us) { return (eff_bytes  / 1e9f) / (us / 1e6f); };
+
+    // ── Naive-A: serial add ───────────────────────────────────────────
+    auto [sa_min, sa_avg] = bench_fn(
+        [&]{ launch_naive_serial_add(d_out_serial, ptrs.data(), num_tensors,
+                                     shard_offset, shard_count, d_fp32, stream); },
+        stream);
+
+    // ── Naive-B: atomic fp32 scatter ─────────────────────────────────
+    auto [at_min, at_avg] = bench_fn(
+        [&]{ launch_naive_atomic(d_out_atomic, ptrs.data(), num_tensors,
+                                 shard_offset, shard_count, d_fp32, stream); },
+        stream);
+
+    // ── Fused hetero kernel ───────────────────────────────────────────
+    auto [fu_min, fu_avg] = bench_fn(
+        [&]{ launch_hetero_reduce_scatter(d_out_fused, ptrs.data(), num_tensors,
+                                          shard_offset, shard_count,
+                                          sm_version, stream); },
+        stream);
+
+    // Build results (speedup vs serial-add median)
+    ConfigResult cr;
+    const float baseline_avg = sa_avg;
+
+    cr.serial_add = {config_tag_buf, "naive_serial_add",
+                     total_elems, shard_count, num_tensors, sm_version,
+                     sa_min, sa_avg, bw_rd(sa_avg), bw_eff(sa_avg), 1.00f};
+
+    cr.atomic_fp32 = {config_tag_buf, "naive_atomic_fp32",
+                      total_elems, shard_count, num_tensors, sm_version,
+                      at_min, at_avg, bw_rd(at_avg), bw_eff(at_avg),
+                      baseline_avg / at_avg};
+
+    cr.hetero_fused = {config_tag_buf, "hetero_fused",
+                       total_elems, shard_count, num_tensors, sm_version,
+                       fu_min, fu_avg, bw_rd(fu_avg), bw_eff(fu_avg),
+                       baseline_avg / fu_avg};
+
+    CUDA_CHECK(cudaFree(d_out_serial));
+    CUDA_CHECK(cudaFree(d_out_atomic));
+    CUDA_CHECK(cudaFree(d_out_fused));
+    CUDA_CHECK(cudaFree(d_fp32));
+    for (int t = 0; t < num_tensors; ++t) CUDA_CHECK(cudaFree(d_in[t]));
+
+    return cr;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §8  Roofline helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Returns approximate HBM peak bandwidth in GB/s for common GPUs.
+// On PCIe clusters we're HBM-bound on the local reduce, so this gives
+// a useful reference line.
+static float peak_hbm_gbps(const cudaDeviceProp& prop)
+{
+    // Approximate from memory clock and bus width (DDR factor = 2).
+    return (float)prop.memoryClockRate * 1e3f   // Hz
+           * (float)prop.memoryBusWidth / 8.f   // bytes per cycle
+           * 2.f                                // DDR
+           / 1e9f;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §9  Regression check: fused must beat serial add at large sizes
+// ─────────────────────────────────────────────────────────────────────────────
+
+static bool regression_check(const std::vector<ConfigResult>& results)
+{
+    bool ok = true;
+    // For large shards (≥4M elements) with ≥4 tensors, the fused kernel must
+    // be at least 1.3× faster than serial add (conservative; typically >2×).
+    for (const auto& cr : results) {
+        if (cr.hetero_fused.shard_count >= 4UL*1024*1024
+            && cr.hetero_fused.num_tensors >= 4) {
+            if (cr.hetero_fused.speedup < 1.30f) {
+                fprintf(stderr,
+                    "[REGRESSION] %s  hetero_fused speedup=%.2f× < 1.30× threshold\n",
+                    cr.hetero_fused.config_tag, cr.hetero_fused.speedup);
+                ok = false;
+            }
+        }
+    }
+    return ok;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §10  main
+// ─────────────────────────────────────────────────────────────────────────────
+
+int main(int argc, char** argv)
+{
+    // ── Parse CLI ────────────────────────────────────────────────────
+    int sm_version = -1;   // -1 → autodetect
+    int warmup_override = -1;
+    int iters_override  = -1;
+    bool regression_mode = false;
+
+    for (int i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "--sm") == 0 && i+1 < argc)
+            sm_version = atoi(argv[++i]);
+        else if (strcmp(argv[i], "--warmup") == 0 && i+1 < argc)
+            warmup_override = atoi(argv[++i]);
+        else if (strcmp(argv[i], "--iters") == 0 && i+1 < argc)
+            iters_override = atoi(argv[++i]);
+        else if (strcmp(argv[i], "--regression") == 0)
+            regression_mode = true;
+        else if (strcmp(argv[i], "--help") == 0) {
+            printf("Usage: %s [--sm 86|90|120] [--warmup N] [--iters N] "
+                   "[--regression]\n", argv[0]);
+            return 0;
+        }
+    }
+
+    // ── Device info ──────────────────────────────────────────────────
+    int dev = 0;
+    CUDA_CHECK(cudaGetDevice(&dev));
+    cudaDeviceProp prop;
+    CUDA_CHECK(cudaGetDeviceProperties(&prop, dev));
+
+    if (sm_version < 0) {
+        sm_version = prop.major * 10 + prop.minor;
+        // Map to nearest supported tier
+        if      (sm_version >= 120) sm_version = 120;
+        else if (sm_version >=  90) sm_version = 90;
+        else                        sm_version = 86;
+    }
+
+    const float peak_hbm = peak_hbm_gbps(prop);
+
+    printf("═══════════════════════════════════════════════════════════════\n");
+    printf("  bench_reduce_scatter_vs_naive  (issue #21)\n");
+    printf("═══════════════════════════════════════════════════════════════\n");
+    printf("  Device : %s  (SM %d.%d, %d SMs)\n",
+           prop.name, prop.major, prop.minor,
+           prop.multiProcessorCount);
+    printf("  Dispatch SM path : SM%d\n", sm_version);
+    printf("  Peak HBM BW (est): %.0f GB/s\n", peak_hbm);
+    printf("  Warmup: %d   Iters: %d\n",
+           warmup_override > 0 ? warmup_override : kWarmup,
+           iters_override  > 0 ? iters_override  : kIter);
+    printf("═══════════════════════════════════════════════════════════════\n\n");
+
+    cudaStream_t stream;
+    CUDA_CHECK(cudaStreamCreate(&stream));
+
+    // ── Correctness check ────────────────────────────────────────────
+    printf("Correctness check ... ");
+    fflush(stdout);
+    bool corr_ok = verify_correctness(sm_version, stream);
+    printf("%s\n\n", corr_ok ? "PASS ✓" : "FAIL ✗");
+    if (!corr_ok) return 1;
+
+    // ── Benchmark sweep ──────────────────────────────────────────────
+    //
+    // Heterogeneous cluster simulation: 5 tiers
+    //   2× A6000 (SM86, weight=1 each) + 1× H100 (SM90, weight=3)
+    //                                  + 2× Blackwell (SM120, weight=4 each)
+    //   Total weight = 1+1+3+4+4 = 13
+    //
+    // This device (index 2 = H100 tier) gets weight/total × total = 3/13 of elems.
+    // We simulate this by setting shard_count = round(total × 3/13).
+    //
+    // For the benchmark we also run with shard_count = total/num_tiers (uniform)
+    // to cleanly compare paths without the weighting math.
+
+    const size_t kTotalSizes[] = {
+        1UL <<  20,   //   1M elements =   2 MB BF16
+        1UL <<  22,   //   4M           =   8 MB
+        1UL <<  24,   //  16M           =  32 MB
+        1UL <<  26,   //  64M           = 128 MB
+        1UL <<  27,   // 128M           = 256 MB (optional, may OOM on small GPUs)
+    };
+    const int kNumSizes = 4;   // skip 128M by default
+
+    const int kNumTensorCounts[] = {2, 4, 8, 16};
+    const int kNumTCs = 4;
+
+    // Shard fraction: 3/13 for the H100 tier in the 5-tier scenario above.
+    // We round to 8-element alignment (kVecWidth).
+    auto compute_h100_shard = [](size_t total) -> size_t {
+        size_t raw = total * 3UL / 13UL;
+        return (raw / 8UL) * 8UL;
+    };
+
+    std::vector<ConfigResult> all_results;
+    all_results.reserve(kNumSizes * kNumTCs);
+
+    print_header_rs();
+
+    for (int si = 0; si < kNumSizes; ++si) {
+        const size_t total  = kTotalSizes[si];
+        const size_t shard  = compute_h100_shard(total);
+        const size_t offset = total * 2UL / 13UL;  // approximate start offset for this tier
+
+        for (int ti = 0; ti < kNumTCs; ++ti) {
+            const int nt = kNumTensorCounts[ti];
+
+            // Rough memory sanity: skip if we'd need > ~4 GB
+            size_t needed_bytes = (size_t)nt * total * 2 + shard * (2 + 4);
+            if (needed_bytes > 4UL * 1024 * 1024 * 1024UL) {
+                printf("  skipping n=%.0fM  nT=%d  (would need %.1f GB)\n",
+                       total * 2.f / (1 << 20), nt,
+                       needed_bytes / 1e9);
+                continue;
+            }
+
+            char tag[64] = {};
+            ConfigResult cr = bench_config(
+                total, offset, shard, nt, sm_version, stream, tag);
+
+            print_rs(cr.serial_add);
+            print_rs(cr.atomic_fp32);
+            print_rs(cr.hetero_fused);
+            printf("\n");
+
+            all_results.push_back(cr);
+        }
+    }
+
+    // ── Roofline analysis ─────────────────────────────────────────────
+    printf("─── Roofline reference ─────────────────────────────────────────\n");
+    printf("  Peak HBM BW : %.0f GB/s\n", peak_hbm);
+    printf("  For hetero_fused, effective BW = (nT+1)×shard_bytes / latency\n");
+    printf("  BW utilisation = eff_GB/s / %.0f\n\n", peak_hbm);
+
+    if (!all_results.empty()) {
+        printf("  BW utilisation summary (hetero_fused, large shards ≥ 16M elems):\n");
+        for (const auto& cr : all_results) {
+            const auto& r = cr.hetero_fused;
+            if (r.shard_count < 4UL*1024*1024) continue;
+            printf("    %-32s  eff=%6.1f GB/s  util=%.0f%%\n",
+                   r.config_tag,
+                   r.bw_eff_gbs,
+                   100.f * r.bw_eff_gbs / peak_hbm);
+        }
+        printf("\n");
+    }
+
+    // ── Summary speedup table ─────────────────────────────────────────
+    printf("─── Speedup summary (hetero_fused vs naive_serial_add) ─────────\n");
+    printf("  %-32s  %7s  %7s\n", "config", "avg_µs", "speedup");
+    for (const auto& cr : all_results) {
+        const auto& r = cr.hetero_fused;
+        printf("  %-32s  %7.1f  %6.2fx\n",
+               r.config_tag, r.avg_us, r.speedup);
+    }
+    printf("\n");
+
+    // ── Regression gate ───────────────────────────────────────────────
+    if (regression_mode) {
+        bool reg_ok = regression_check(all_results);
+        printf("Regression check: %s\n", reg_ok ? "PASS ✓" : "FAIL ✗");
+        cudaStreamDestroy(stream);
+        return reg_ok ? 0 : 2;
+    }
+
+    printf("Benchmark complete.\n");
+    CUDA_CHECK(cudaStreamDestroy(stream));
+    return 0;
+}

--- a/benchmarks/bench_swiglu_ln.cu
+++ b/benchmarks/bench_swiglu_ln.cu
@@ -1,0 +1,462 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * bench_swiglu_ln.cu — Benchmark: fused SwiGLU+RMSNorm vs unfused baseline
+ *
+ * Partially addresses https://github.com/dylanyunlon/Neuron_SP/issues/25
+ *
+ * Compiles as a standalone binary.  Requires CUDA ≥ 11.0 with BF16 support.
+ *
+ *   nvcc -O3 -std=c++17 -arch=sm_86              \
+ *        -I../csrc/includes -I../csrc/hetero_reduce \
+ *        bench_swiglu_ln.cu -o bench_swiglu_ln
+ *
+ * Usage:
+ *   ./bench_swiglu_ln [batch] [hidden] [warmup_iters] [bench_iters]
+ *   defaults: batch=128, hidden=4096, warmup=50, bench=200
+ *
+ * Output:
+ *   - Fused kernel latency (µs)
+ *   - Unfused baseline latency (µs)
+ *   - Speedup ratio
+ *   - Effective bandwidth (GB/s) for each
+ *   - Roofline: fraction of theoretical HBM peak
+ *   - Numerical correctness check (max abs error)
+ */
+
+#include <cuda.h>
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cooperative_groups.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <cfloat>
+#include <vector>
+
+// ─── Project headers (for DS_D_INLINE, hw_warp_size) ─────────────────────────
+#include "ds_kernel_utils.h"
+#include "hetero_reduce.h"
+
+// ─── Error-checking macro ────────────────────────────────────────────────────
+#define CUDA_CHECK(call)                                                       \
+    do {                                                                       \
+        cudaError_t err = (call);                                              \
+        if (err != cudaSuccess) {                                              \
+            fprintf(stderr, "CUDA error at %s:%d — %s\n", __FILE__, __LINE__, \
+                    cudaGetErrorString(err));                                   \
+            exit(EXIT_FAILURE);                                                \
+        }                                                                      \
+    } while (0)
+
+namespace cg = cooperative_groups;
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section A: Unfused baseline kernels (separate SwiGLU + separate RMSNorm)
+// ═════════════════════════════════════════════════════════════════════════════
+
+// Kernel 1: SwiGLU activation only — writes intermediate buffer
+__global__ void unfused_swiglu_kernel(
+    __nv_bfloat16* __restrict__       swiglu_out,
+    const __nv_bfloat16* __restrict__ gate_proj,
+    const __nv_bfloat16* __restrict__ up_proj,
+    int hidden)
+{
+    const int row = blockIdx.x;
+    const int tid = threadIdx.x;
+    const __nv_bfloat16* g_row = gate_proj + (size_t)row * hidden;
+    const __nv_bfloat16* u_row = up_proj   + (size_t)row * hidden;
+    __nv_bfloat16*       o_row = swiglu_out + (size_t)row * hidden;
+
+    for (int col = tid; col < hidden; col += blockDim.x) {
+        float gv = __bfloat162float(g_row[col]);
+        float uv = __bfloat162float(u_row[col]);
+        float sigmoid_g = 1.f / (1.f + __expf(-gv));
+        float sw = gv * sigmoid_g * uv;
+        o_row[col] = __float2bfloat16(sw);
+    }
+}
+
+// Kernel 2: RMSNorm on pre-computed SwiGLU output
+__global__ void unfused_rmsnorm_kernel(
+    __nv_bfloat16* __restrict__       output,
+    const __nv_bfloat16* __restrict__ input,
+    const float* __restrict__         ln_weight,
+    int hidden,
+    float eps)
+{
+    const int row = blockIdx.x;
+    const __nv_bfloat16* in_row  = input  + (size_t)row * hidden;
+    __nv_bfloat16*       out_row = output + (size_t)row * hidden;
+
+    // Pass 1: compute sum of squares
+    float sq_sum = 0.f;
+    for (int col = threadIdx.x; col < hidden; col += blockDim.x) {
+        float v = __bfloat162float(in_row[col]);
+        sq_sum += v * v;
+    }
+
+    // Warp reduction
+    for (int offset = warpSize / 2; offset > 0; offset >>= 1)
+        sq_sum += __shfl_xor_sync(0xffffffff, sq_sum, offset);
+
+    // Block reduction via shared memory
+    __shared__ float smem[32];
+    int lane = threadIdx.x % warpSize;
+    int wid  = threadIdx.x / warpSize;
+    if (lane == 0) smem[wid] = sq_sum;
+    __syncthreads();
+
+    sq_sum = (threadIdx.x < blockDim.x / warpSize) ? smem[threadIdx.x] : 0.f;
+    if (wid == 0) {
+        for (int offset = warpSize / 2; offset > 0; offset >>= 1)
+            sq_sum += __shfl_xor_sync(0xffffffff, sq_sum, offset);
+    }
+    if (threadIdx.x == 0) smem[0] = sq_sum;
+    __syncthreads();
+    sq_sum = smem[0];
+
+    float rms_inv = rsqrtf(sq_sum / (float)hidden + eps);
+
+    // Pass 2: normalize
+    for (int col = threadIdx.x; col < hidden; col += blockDim.x) {
+        float v = __bfloat162float(in_row[col]);
+        float w = ln_weight[col];
+        out_row[col] = __float2bfloat16(v * rms_inv * w);
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section B: Include the fused kernel from the main source
+//   We re-declare the host-side launcher declared in fused_swiglu_ln.cu.
+// ═════════════════════════════════════════════════════════════════════════════
+
+extern void launch_fused_swiglu_ln(
+    __nv_bfloat16*       output,
+    const __nv_bfloat16* gate_proj,
+    const __nv_bfloat16* up_proj,
+    const float*         ln_weight,
+    int                  batch,
+    int                  hidden,
+    float                eps,
+    int                  sm_version,
+    cudaStream_t         stream);
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section C: Roofline helper
+// ═════════════════════════════════════════════════════════════════════════════
+
+struct DeviceRoofline {
+    double peak_bw_gb_s;   // theoretical HBM bandwidth (GB/s)
+    double peak_flops_gf;  // theoretical BF16 TFLOPS  (unused for mem-bound)
+    const char* gpu_name;
+};
+
+static DeviceRoofline get_device_roofline()
+{
+    cudaDeviceProp prop;
+    CUDA_CHECK(cudaGetDeviceProperties(&prop, 0));
+
+    // peak bandwidth = memory_clock_rate (kHz) × bus_width (bits) × 2 (DDR) / 8
+    double bw = (double)prop.memoryClockRate * 1e3          // Hz
+                * ((double)prop.memoryBusWidth / 8.0)       // bytes per clock per dir
+                * 2.0                                       // DDR
+                / 1e9;                                      // → GB/s
+
+    DeviceRoofline r;
+    r.peak_bw_gb_s  = bw;
+    r.peak_flops_gf = 0.0;  // not used for this bandwidth-bound kernel
+    r.gpu_name      = prop.name;
+    return r;
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section D: Timing utility
+// ═════════════════════════════════════════════════════════════════════════════
+
+struct BenchResult {
+    double mean_us;
+    double min_us;
+    double max_us;
+    double eff_bw_gb_s;
+    double roofline_pct;
+};
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section E: main()
+// ═════════════════════════════════════════════════════════════════════════════
+
+int main(int argc, char** argv)
+{
+    // ── Parse CLI args ──────────────────────────────────────────────────────
+    int batch        = (argc > 1) ? atoi(argv[1]) : 128;
+    int hidden       = (argc > 2) ? atoi(argv[2]) : 4096;
+    int warmup_iters = (argc > 3) ? atoi(argv[3]) : 50;
+    int bench_iters  = (argc > 4) ? atoi(argv[4]) : 200;
+    float eps        = 1e-6f;
+
+    printf("═══════════════════════════════════════════════════════════════\n");
+    printf("  Benchmark: Fused SwiGLU+RMSNorm  vs  Unfused Baseline\n");
+    printf("  batch=%d  hidden=%d  warmup=%d  iters=%d  eps=%.1e\n",
+           batch, hidden, warmup_iters, bench_iters, eps);
+    printf("═══════════════════════════════════════════════════════════════\n\n");
+
+    // ── Device info & roofline ──────────────────────────────────────────────
+    cudaDeviceProp prop;
+    CUDA_CHECK(cudaGetDeviceProperties(&prop, 0));
+    int sm_version = prop.major * 10 + prop.minor;
+
+    DeviceRoofline roof = get_device_roofline();
+    printf("  GPU:            %s  (SM %d.%d)\n", prop.name, prop.major, prop.minor);
+    printf("  Peak HBM BW:    %.1f GB/s (theoretical)\n", roof.peak_bw_gb_s);
+    printf("\n");
+
+    // ── Allocate device memory ──────────────────────────────────────────────
+    size_t n_elem       = (size_t)batch * hidden;
+    size_t bf16_bytes   = n_elem * sizeof(__nv_bfloat16);
+    size_t weight_bytes = (size_t)hidden * sizeof(float);
+
+    __nv_bfloat16 *d_gate, *d_up, *d_out_fused, *d_out_unfused, *d_swiglu_tmp;
+    float *d_ln_weight;
+
+    CUDA_CHECK(cudaMalloc(&d_gate,        bf16_bytes));
+    CUDA_CHECK(cudaMalloc(&d_up,          bf16_bytes));
+    CUDA_CHECK(cudaMalloc(&d_out_fused,   bf16_bytes));
+    CUDA_CHECK(cudaMalloc(&d_out_unfused, bf16_bytes));
+    CUDA_CHECK(cudaMalloc(&d_swiglu_tmp,  bf16_bytes));   // unfused intermediate
+    CUDA_CHECK(cudaMalloc(&d_ln_weight,   weight_bytes));
+
+    // ── Initialise with random data ─────────────────────────────────────────
+    std::vector<__nv_bfloat16> h_gate(n_elem), h_up(n_elem);
+    std::vector<float> h_weight(hidden);
+
+    srand(42);
+    for (size_t i = 0; i < n_elem; ++i) {
+        h_gate[i] = __float2bfloat16((float)(rand() % 1000 - 500) / 500.f);
+        h_up[i]   = __float2bfloat16((float)(rand() % 1000 - 500) / 500.f);
+    }
+    for (int i = 0; i < hidden; ++i)
+        h_weight[i] = 0.5f + (float)(rand() % 1000) / 1000.f;
+
+    CUDA_CHECK(cudaMemcpy(d_gate,      h_gate.data(),   bf16_bytes,   cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_up,        h_up.data(),     bf16_bytes,   cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_ln_weight, h_weight.data(), weight_bytes, cudaMemcpyHostToDevice));
+
+    // ── Memory traffic calculation (bytes) ──────────────────────────────────
+    //
+    // Fused kernel (single-pass):
+    //   reads:  gate(bf16) + up(bf16) + ln_weight(f32)
+    //   writes: output(bf16)
+    //   total = batch*hidden*2 (gate) + batch*hidden*2 (up)
+    //         + hidden*4 (weight, amortised) + batch*hidden*2 (output)
+    //         = batch*hidden*6 + hidden*4
+    //
+    // Unfused baseline:
+    //   swiglu kernel:  reads gate+up, writes tmp
+    //     = batch*hidden*(2+2+2) = batch*hidden*6
+    //   rmsnorm kernel: reads tmp + weight, writes output
+    //     Pass1: reads tmp → batch*hidden*2
+    //     Pass2: reads tmp + weight, writes output → batch*hidden*(2+4/batch+2)
+    //     ≈ batch*hidden*6 + hidden*4  (two full passes over tmp)
+    //   total ≈ batch*hidden*12 + hidden*4
+    //
+    double fused_bytes   = (double)batch * hidden * 6.0 + (double)hidden * 4.0;
+    double unfused_bytes = (double)batch * hidden * 12.0 + (double)hidden * 4.0;
+
+    printf("  Memory traffic (estimated):\n");
+    printf("    Fused:   %.2f MB\n", fused_bytes / 1e6);
+    printf("    Unfused: %.2f MB\n", unfused_bytes / 1e6);
+    printf("\n");
+
+    // ── CUDA events for timing ──────────────────────────────────────────────
+    cudaEvent_t start, stop;
+    CUDA_CHECK(cudaEventCreate(&start));
+    CUDA_CHECK(cudaEventCreate(&stop));
+
+    cudaStream_t stream;
+    CUDA_CHECK(cudaStreamCreate(&stream));
+
+    // Block size for unfused kernels
+    const int unfused_block = 256;
+
+    // ── Warmup: fused ────────────────────────────────────────────────────────
+    for (int i = 0; i < warmup_iters; ++i) {
+        launch_fused_swiglu_ln(d_out_fused, d_gate, d_up, d_ln_weight,
+                               batch, hidden, eps, sm_version, stream);
+    }
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+
+    // ── Benchmark: fused ────────────────────────────────────────────────────
+    CUDA_CHECK(cudaEventRecord(start, stream));
+    for (int i = 0; i < bench_iters; ++i) {
+        launch_fused_swiglu_ln(d_out_fused, d_gate, d_up, d_ln_weight,
+                               batch, hidden, eps, sm_version, stream);
+    }
+    CUDA_CHECK(cudaEventRecord(stop, stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+
+    float fused_ms = 0.f;
+    CUDA_CHECK(cudaEventElapsedTime(&fused_ms, start, stop));
+    double fused_us = (double)fused_ms * 1000.0 / bench_iters;
+    double fused_bw = fused_bytes / (fused_us * 1e-6) / 1e9;   // GB/s
+    double fused_roof = fused_bw / roof.peak_bw_gb_s * 100.0;
+
+    // ── Warmup: unfused ─────────────────────────────────────────────────────
+    for (int i = 0; i < warmup_iters; ++i) {
+        unfused_swiglu_kernel<<<batch, unfused_block, 0, stream>>>(
+            d_swiglu_tmp, d_gate, d_up, hidden);
+        unfused_rmsnorm_kernel<<<batch, unfused_block, 0, stream>>>(
+            d_out_unfused, d_swiglu_tmp, d_ln_weight, hidden, eps);
+    }
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+
+    // ── Benchmark: unfused ──────────────────────────────────────────────────
+    CUDA_CHECK(cudaEventRecord(start, stream));
+    for (int i = 0; i < bench_iters; ++i) {
+        unfused_swiglu_kernel<<<batch, unfused_block, 0, stream>>>(
+            d_swiglu_tmp, d_gate, d_up, hidden);
+        unfused_rmsnorm_kernel<<<batch, unfused_block, 0, stream>>>(
+            d_out_unfused, d_swiglu_tmp, d_ln_weight, hidden, eps);
+    }
+    CUDA_CHECK(cudaEventRecord(stop, stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+
+    float unfused_ms = 0.f;
+    CUDA_CHECK(cudaEventElapsedTime(&unfused_ms, start, stop));
+    double unfused_us = (double)unfused_ms * 1000.0 / bench_iters;
+    double unfused_bw = unfused_bytes / (unfused_us * 1e-6) / 1e9;
+    double unfused_roof = unfused_bw / roof.peak_bw_gb_s * 100.0;
+
+    // ── Numerical correctness ───────────────────────────────────────────────
+    std::vector<__nv_bfloat16> h_fused(n_elem), h_unfused(n_elem);
+    CUDA_CHECK(cudaMemcpy(h_fused.data(),   d_out_fused,   bf16_bytes, cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_unfused.data(), d_out_unfused, bf16_bytes, cudaMemcpyDeviceToHost));
+
+    float max_abs_err = 0.f;
+    double sum_abs_err = 0.0;
+    for (size_t i = 0; i < n_elem; ++i) {
+        float fv = __bfloat162float(h_fused[i]);
+        float uv = __bfloat162float(h_unfused[i]);
+        float ae = fabsf(fv - uv);
+        if (ae > max_abs_err) max_abs_err = ae;
+        sum_abs_err += ae;
+    }
+    float mean_abs_err = (float)(sum_abs_err / n_elem);
+
+    // ── Print results ───────────────────────────────────────────────────────
+    printf("─────────────────────────────────────────────────────────────\n");
+    printf("  RESULTS\n");
+    printf("─────────────────────────────────────────────────────────────\n");
+    printf("  %-22s %10s %10s %10s\n", "", "Fused", "Unfused", "Ratio");
+    printf("  %-22s %9.1f µs %8.1f µs %9.2fx\n",
+           "Latency",    fused_us, unfused_us, unfused_us / fused_us);
+    printf("  %-22s %8.1f GB/s %6.1f GB/s %9.2fx\n",
+           "Eff. bandwidth", fused_bw, unfused_bw, fused_bw / unfused_bw);
+    printf("  %-22s %9.1f %%  %8.1f %%\n",
+           "Roofline (%% peak)", fused_roof, unfused_roof);
+    printf("─────────────────────────────────────────────────────────────\n");
+    printf("  Correctness:  max|err|=%.6f  mean|err|=%.8f\n",
+           max_abs_err, mean_abs_err);
+    printf("  (BF16 has ~0.01 relative precision; small diffs expected)\n");
+    printf("─────────────────────────────────────────────────────────────\n\n");
+
+    // ── Roofline analysis ───────────────────────────────────────────────────
+    printf("  ROOFLINE ANALYSIS\n");
+    printf("─────────────────────────────────────────────────────────────\n");
+    printf("  This kernel is memory-bandwidth-bound (arithmetic intensity\n");
+    printf("  ≈ 5 FLOPs/element ÷ 6 bytes/element ≈ 0.83 FLOP/byte).\n");
+    printf("  The fused kernel eliminates the intermediate BF16 buffer,\n");
+    printf("  cutting DRAM traffic from ~%.0f MB to ~%.0f MB (%.1fx).\n",
+           unfused_bytes / 1e6, fused_bytes / 1e6,
+           unfused_bytes / fused_bytes);
+    printf("\n");
+    printf("  Theoretical peak HBM bandwidth: %.1f GB/s\n", roof.peak_bw_gb_s);
+    printf("  Fused achieved:   %6.1f GB/s  (%.1f%% of peak)\n",
+           fused_bw, fused_roof);
+    printf("  Unfused achieved: %6.1f GB/s  (%.1f%% of peak)\n",
+           unfused_bw, unfused_roof);
+    printf("─────────────────────────────────────────────────────────────\n");
+
+    // ── Sweep hidden sizes ──────────────────────────────────────────────────
+    printf("\n  HIDDEN-SIZE SWEEP (batch=%d)\n", batch);
+    printf("─────────────────────────────────────────────────────────────\n");
+    printf("  %8s  %10s  %10s  %8s\n", "hidden", "fused(µs)", "unfused(µs)", "speedup");
+
+    int hidden_sizes[] = {1024, 2048, 4096, 8192, 11008, 13824, 16384};
+    for (int h : hidden_sizes) {
+        size_t ne = (size_t)batch * h;
+        size_t nb = ne * sizeof(__nv_bfloat16);
+        size_t wb = (size_t)h * sizeof(float);
+
+        // Realloc if bigger
+        __nv_bfloat16 *dg, *du, *do_f, *do_u, *dt;
+        float *dw;
+        CUDA_CHECK(cudaMalloc(&dg,   nb));
+        CUDA_CHECK(cudaMalloc(&du,   nb));
+        CUDA_CHECK(cudaMalloc(&do_f, nb));
+        CUDA_CHECK(cudaMalloc(&do_u, nb));
+        CUDA_CHECK(cudaMalloc(&dt,   nb));
+        CUDA_CHECK(cudaMalloc(&dw,   wb));
+        CUDA_CHECK(cudaMemset(dg, 0x3f, nb));  // fill with non-zero BF16
+        CUDA_CHECK(cudaMemset(du, 0x3f, nb));
+        // init weight to 1.0f
+        std::vector<float> ones(h, 1.0f);
+        CUDA_CHECK(cudaMemcpy(dw, ones.data(), wb, cudaMemcpyHostToDevice));
+
+        // warmup
+        for (int i = 0; i < 20; ++i) {
+            launch_fused_swiglu_ln(do_f, dg, du, dw, batch, h, eps, sm_version, stream);
+            unfused_swiglu_kernel<<<batch, unfused_block, 0, stream>>>(dt, dg, du, h);
+            unfused_rmsnorm_kernel<<<batch, unfused_block, 0, stream>>>(do_u, dt, dw, h, eps);
+        }
+        CUDA_CHECK(cudaStreamSynchronize(stream));
+
+        // bench fused
+        CUDA_CHECK(cudaEventRecord(start, stream));
+        for (int i = 0; i < bench_iters; ++i)
+            launch_fused_swiglu_ln(do_f, dg, du, dw, batch, h, eps, sm_version, stream);
+        CUDA_CHECK(cudaEventRecord(stop, stream));
+        CUDA_CHECK(cudaStreamSynchronize(stream));
+        float f_ms;
+        CUDA_CHECK(cudaEventElapsedTime(&f_ms, start, stop));
+        double f_us = (double)f_ms * 1000.0 / bench_iters;
+
+        // bench unfused
+        CUDA_CHECK(cudaEventRecord(start, stream));
+        for (int i = 0; i < bench_iters; ++i) {
+            unfused_swiglu_kernel<<<batch, unfused_block, 0, stream>>>(dt, dg, du, h);
+            unfused_rmsnorm_kernel<<<batch, unfused_block, 0, stream>>>(do_u, dt, dw, h, eps);
+        }
+        CUDA_CHECK(cudaEventRecord(stop, stream));
+        CUDA_CHECK(cudaStreamSynchronize(stream));
+        float u_ms;
+        CUDA_CHECK(cudaEventElapsedTime(&u_ms, start, stop));
+        double u_us = (double)u_ms * 1000.0 / bench_iters;
+
+        printf("  %8d  %9.1f µs  %9.1f µs  %7.2fx\n",
+               h, f_us, u_us, u_us / f_us);
+
+        CUDA_CHECK(cudaFree(dg));
+        CUDA_CHECK(cudaFree(du));
+        CUDA_CHECK(cudaFree(do_f));
+        CUDA_CHECK(cudaFree(do_u));
+        CUDA_CHECK(cudaFree(dt));
+        CUDA_CHECK(cudaFree(dw));
+    }
+    printf("─────────────────────────────────────────────────────────────\n");
+
+    // ── Cleanup ─────────────────────────────────────────────────────────────
+    CUDA_CHECK(cudaFree(d_gate));
+    CUDA_CHECK(cudaFree(d_up));
+    CUDA_CHECK(cudaFree(d_out_fused));
+    CUDA_CHECK(cudaFree(d_out_unfused));
+    CUDA_CHECK(cudaFree(d_swiglu_tmp));
+    CUDA_CHECK(cudaFree(d_ln_weight));
+    CUDA_CHECK(cudaEventDestroy(start));
+    CUDA_CHECK(cudaEventDestroy(stop));
+    CUDA_CHECK(cudaStreamDestroy(stream));
+
+    printf("\nDone.\n");
+    return 0;
+}


### PR DESCRIPTION
Cherry-picks benchmark files from PRs #54, #55, #56 (which had unrelated deletions mixed in). Adds 1721 lines of CUDA benchmarks for hetero_reduce kernels.

Addresses #83